### PR TITLE
Add validation when setting reference value during page and variant creation and update

### DIFF
--- a/saleor/graphql/page/tests/mutations/test_page_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_create.py
@@ -711,6 +711,126 @@ def test_create_page_with_page_reference_attribute(
     assert page_type_page_reference_attribute.values.count() == values_count + 1
 
 
+def test_create_page_with_reference_attributes_and_reference_types_defined(
+    staff_api_client,
+    page_type,
+    page_type_page_reference_attribute,
+    page_type_product_reference_attribute,
+    page_type_variant_reference_attribute,
+    page,
+    product,
+    variant,
+    permission_manage_pages,
+):
+    # given
+    page_type.page_attributes.clear()
+    page_type.page_attributes.add(
+        page_type_page_reference_attribute,
+        page_type_product_reference_attribute,
+        page_type_variant_reference_attribute,
+    )
+
+    page_type_page_reference_attribute.reference_page_types.add(page.page_type)
+    page_type_product_reference_attribute.reference_product_types.add(
+        product.product_type
+    )
+    page_type_variant_reference_attribute.reference_product_types.add(
+        variant.product.product_type
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_page_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_variant_reference_attribute.id
+    )
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    page_title = "test title"
+    page_slug = "test-slug"
+    page_type_id = graphene.Node.to_global_id("PageType", page_type.pk)
+
+    variables = {
+        "input": {
+            "title": page_title,
+            "slug": page_slug,
+            "pageType": page_type_id,
+            "attributes": [
+                {"id": page_ref_attr_id, "references": [page_ref]},
+                {"id": product_ref_attr_id, "references": [product_ref]},
+                {"id": variant_ref_attr_id, "references": [variant_ref]},
+            ],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_PAGE_MUTATION, variables, permissions=[permission_manage_pages]
+    )
+
+    # then
+    content = get_graphql_content(response)["data"]["pageCreate"]
+
+    assert not content["errors"]
+    data = content["page"]
+    assert data["title"] == page_title
+    assert data["slug"] == page_slug
+    page_id = data["id"]
+    _, page_pk = graphene.Node.from_global_id(page_id)
+    assert len(data["attributes"]) == len(variables["input"]["attributes"])
+    expected_attributes_data = [
+        {
+            "attribute": {"slug": page_type_page_reference_attribute.slug},
+            "values": [
+                {
+                    "slug": f"{page_pk}_{page.id}",
+                    "file": None,
+                    "plainText": None,
+                    "reference": page_ref,
+                    "name": page.title,
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+        {
+            "attribute": {"slug": page_type_product_reference_attribute.slug},
+            "values": [
+                {
+                    "slug": f"{page_pk}_{product.id}",
+                    "file": None,
+                    "plainText": None,
+                    "reference": product_ref,
+                    "name": product.name,
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+        {
+            "attribute": {"slug": page_type_variant_reference_attribute.slug},
+            "values": [
+                {
+                    "slug": f"{page_pk}_{variant.id}",
+                    "file": None,
+                    "plainText": None,
+                    "reference": variant_ref,
+                    "name": f"{variant.product.name}: {variant.name}",
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+    ]
+    for attr_data in data["attributes"]:
+        assert attr_data in expected_attributes_data
+
+
 @freeze_time(datetime.datetime(2020, 5, 5, 5, 5, 5, tzinfo=datetime.UTC))
 def test_create_page_with_date_attribute(
     staff_api_client,
@@ -993,6 +1113,87 @@ def test_create_page_with_page_reference_attribute_required_no_references_given(
     assert errors[0]["code"] == PageErrorCode.REQUIRED.name
     assert errors[0]["field"] == "attributes"
     assert errors[0]["attributes"] == [file_attribute_id]
+
+
+def test_create_page_with_reference_attributes_ref_not_in_available_choices(
+    staff_api_client,
+    page_type,
+    page_type_page_reference_attribute,
+    page_type_product_reference_attribute,
+    page_type_variant_reference_attribute,
+    page,
+    product,
+    variant,
+    page_type_list,
+    permission_manage_pages,
+    product_type_with_variant_attributes,
+):
+    # given
+    page_type.page_attributes.clear()
+    page_type.page_attributes.add(
+        page_type_page_reference_attribute,
+        page_type_product_reference_attribute,
+        page_type_variant_reference_attribute,
+    )
+
+    # assigned reference types that do not match product/page types of references
+    # that are provided in the input
+    page_type_page_reference_attribute.reference_page_types.add(page_type_list[1])
+    page_type_product_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+    page_type_variant_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_page_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_variant_reference_attribute.id
+    )
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    page_title = "test title"
+    page_slug = "test-slug"
+    page_type_id = graphene.Node.to_global_id("PageType", page_type.pk)
+
+    variables = {
+        "input": {
+            "title": page_title,
+            "slug": page_slug,
+            "pageType": page_type_id,
+            "attributes": [
+                {"id": page_ref_attr_id, "references": [page_ref]},
+                {"id": product_ref_attr_id, "references": [product_ref]},
+                {"id": variant_ref_attr_id, "references": [variant_ref]},
+            ],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_PAGE_MUTATION, variables, permissions=[permission_manage_pages]
+    )
+
+    # then
+    content = get_graphql_content(response)["data"]["pageCreate"]
+
+    errors = content["errors"]
+    assert not content["page"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PageErrorCode.INVALID.name
+    assert errors[0]["field"] == "attributes"
+    assert set(errors[0]["attributes"]) == {
+        page_ref_attr_id,
+        product_ref_attr_id,
+        variant_ref_attr_id,
+    }
 
 
 def test_create_page_with_product_reference_attribute(

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -582,6 +582,126 @@ def test_update_page_with_plain_text_attribute_new_value(
     assert plain_text_attribute_page_type.values.count() == values_count + 1
 
 
+def test_update_page_with_reference_attributes_and_reference_types_defined(
+    staff_api_client,
+    page_list,
+    product,
+    variant,
+    page_type_page_reference_attribute,
+    page_type_product_reference_attribute,
+    page_type_variant_reference_attribute,
+    permission_manage_pages,
+):
+    # given
+    page = page_list[0]
+    page.page_type.page_attributes.clear()
+    page.page_type.page_attributes.add(
+        page_type_page_reference_attribute,
+        page_type_product_reference_attribute,
+        page_type_variant_reference_attribute,
+    )
+
+    reference_page = page_list[1]
+
+    page_type_page_reference_attribute.reference_page_types.add(
+        reference_page.page_type
+    )
+    page_type_product_reference_attribute.reference_product_types.add(
+        product.product_type
+    )
+    page_type_variant_reference_attribute.reference_product_types.add(
+        variant.product.product_type
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_page_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_variant_reference_attribute.id
+    )
+    page_ref = graphene.Node.to_global_id("Page", reference_page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    page_id = graphene.Node.to_global_id("Page", page.pk)
+    variables = {
+        "id": page_id,
+        "input": {
+            "attributes": [
+                {"id": page_ref_attr_id, "references": [page_ref]},
+                {"id": product_ref_attr_id, "references": [product_ref]},
+                {"id": variant_ref_attr_id, "references": [variant_ref]},
+            ]
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        UPDATE_PAGE_ATTRIBUTES_MUTATION,
+        variables,
+        permissions=[permission_manage_pages],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageUpdate"]
+    assert not data["errors"]
+    attributes_data = data["page"]["attributes"]
+    assert len(attributes_data) == len(variables["input"]["attributes"])
+    expected_attributes_data = [
+        {
+            "attribute": {"slug": page_type_page_reference_attribute.slug},
+            "values": [
+                {
+                    "id": ANY,
+                    "slug": f"{page.pk}_{reference_page.pk}",
+                    "file": None,
+                    "plainText": None,
+                    "reference": page_ref,
+                    "name": reference_page.title,
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+        {
+            "attribute": {"slug": page_type_product_reference_attribute.slug},
+            "values": [
+                {
+                    "id": ANY,
+                    "slug": f"{page.pk}_{product.pk}",
+                    "file": None,
+                    "plainText": None,
+                    "reference": product_ref,
+                    "name": product.name,
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+        {
+            "attribute": {"slug": page_type_variant_reference_attribute.slug},
+            "values": [
+                {
+                    "id": ANY,
+                    "slug": f"{page.pk}_{variant.pk}",
+                    "file": None,
+                    "plainText": None,
+                    "reference": variant_ref,
+                    "name": f"{variant.product.name}: {variant.name}",
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+    ]
+    for attr_data in attributes_data:
+        assert attr_data in expected_attributes_data
+
+
 def test_update_page_with_plain_text_attribute_existing_value(
     staff_api_client,
     permission_manage_pages,
@@ -1035,6 +1155,88 @@ def test_update_page_with_collection_reference_attribute_new_value(
     assert page_type_collection_reference_attribute.values.count() == values_count + 1
 
 
+def test_update_page_with_reference_attributes_ref_not_in_available_choices(
+    staff_api_client,
+    page_list,
+    product,
+    variant,
+    page_type_page_reference_attribute,
+    page_type_product_reference_attribute,
+    page_type_variant_reference_attribute,
+    permission_manage_pages,
+    product_type_with_variant_attributes,
+    page_type_with_rich_text_attribute,
+):
+    # given
+    page = page_list[0]
+    page.page_type.page_attributes.clear()
+    page.page_type.page_attributes.add(
+        page_type_page_reference_attribute,
+        page_type_product_reference_attribute,
+        page_type_variant_reference_attribute,
+    )
+
+    reference_page = page_list[1]
+    # assigned reference types that do not match product/page types of references
+    # that are provided in the input
+    page_type_page_reference_attribute.reference_page_types.add(
+        page_type_with_rich_text_attribute
+    )
+    page_type_product_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+    page_type_variant_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_page_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", page_type_variant_reference_attribute.id
+    )
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    page_ref = graphene.Node.to_global_id("Page", reference_page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+
+    page_id = graphene.Node.to_global_id("Page", page.pk)
+    variables = {
+        "id": page_id,
+        "input": {
+            "attributes": [
+                {"id": page_ref_attr_id, "references": [page_ref]},
+                {"id": product_ref_attr_id, "references": [product_ref]},
+                {"id": variant_ref_attr_id, "references": [variant_ref]},
+            ]
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        UPDATE_PAGE_ATTRIBUTES_MUTATION,
+        variables,
+        permissions=[permission_manage_pages],
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    data = content["data"]["pageUpdate"]
+    errors = data["errors"]
+    assert not data["page"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PageErrorCode.INVALID.name
+    assert errors[0]["field"] == "attributes"
+    assert set(errors[0]["attributes"]) == {
+        page_ref_attr_id,
+        product_ref_attr_id,
+        variant_ref_attr_id,
+    }
+
+
 @freeze_time("2020-03-18 12:00:00")
 def test_public_page_sets_publication_date(
     staff_api_client, permission_manage_pages, page_type
@@ -1178,6 +1380,7 @@ UPDATE_PAGE_ATTRIBUTES_MUTATION = """
                 field
                 code
                 message
+                attributes
             }
         }
     }

--- a/saleor/graphql/product/tests/mutations/test_product_variant_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_create.py
@@ -1320,6 +1320,139 @@ def test_create_variant_with_collection_reference_attribute(
     created_webhook_mock.assert_called_once_with(product.variants.last())
 
 
+def test_create_variant_with_reference_attributes_and_reference_types_defined(
+    staff_api_client,
+    product,
+    product_type,
+    product_type_page_reference_attribute,
+    product_type_product_reference_attribute,
+    product_type_variant_reference_attribute,
+    page,
+    permission_manage_products,
+    warehouse,
+    variant,
+):
+    # given
+    query = CREATE_VARIANT_MUTATION
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    sku = "1"
+
+    product_type.variant_attributes.clear()
+    product_type.variant_attributes.add(
+        product_type_page_reference_attribute,
+        product_type_product_reference_attribute,
+        product_type_variant_reference_attribute,
+    )
+
+    product_type_page_reference_attribute.reference_page_types.add(page.page_type)
+    product_type_product_reference_attribute.reference_product_types.add(
+        product.product_type
+    )
+    product_type_variant_reference_attribute.reference_product_types.add(
+        variant.product.product_type
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_page_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_variant_reference_attribute.id
+    )
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+
+    stocks = [
+        {
+            "warehouse": graphene.Node.to_global_id("Warehouse", warehouse.pk),
+            "quantity": 20,
+        }
+    ]
+
+    variables = {
+        "input": {
+            "product": product_id,
+            "sku": sku,
+            "stocks": stocks,
+            "attributes": [
+                {"id": page_ref_attr_id, "references": [page_ref]},
+                {"id": product_ref_attr_id, "references": [product_ref]},
+                {"id": variant_ref_attr_id, "references": [variant_ref]},
+            ],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    content = get_graphql_content(response)["data"]["productVariantCreate"]
+
+    assert not content["errors"]
+    data = content["productVariant"]
+    assert data["sku"] == sku
+    variant_id = data["id"]
+    _, variant_pk = graphene.Node.from_global_id(variant_id)
+    assert len(data["attributes"]) == len(variables["input"]["attributes"])
+    expected_attributes_data = [
+        {
+            "attribute": {"slug": product_type_page_reference_attribute.slug},
+            "values": [
+                {
+                    "slug": f"{variant_pk}_{page.id}",
+                    "file": None,
+                    "richText": None,
+                    "plainText": None,
+                    "reference": page_ref,
+                    "name": page.title,
+                    "boolean": None,
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+        {
+            "attribute": {"slug": product_type_product_reference_attribute.slug},
+            "values": [
+                {
+                    "slug": f"{variant_pk}_{product.id}",
+                    "file": None,
+                    "richText": None,
+                    "plainText": None,
+                    "reference": product_ref,
+                    "name": product.name,
+                    "boolean": None,
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+        {
+            "attribute": {"slug": product_type_variant_reference_attribute.slug},
+            "values": [
+                {
+                    "slug": f"{variant_pk}_{variant.id}",
+                    "file": None,
+                    "richText": None,
+                    "plainText": None,
+                    "reference": variant_ref,
+                    "name": f"{variant.product.name}: {variant.name}",
+                    "boolean": None,
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+    ]
+    for attr_data in data["attributes"]:
+        assert attr_data in expected_attributes_data
+
+
 @patch("saleor.plugins.manager.PluginsManager.product_variant_created")
 def test_create_variant_with_single_reference_attributes(
     created_webhook_mock,
@@ -1779,6 +1912,95 @@ def test_create_variant_invalid_variant_attributes(
     ]
     for error in expected_errors:
         assert error in errors
+
+
+def test_create_variant_with_reference_attributes_ref_not_in_available_choices(
+    staff_api_client,
+    product,
+    product_type,
+    product_type_with_variant_attributes,
+    product_type_page_reference_attribute,
+    product_type_product_reference_attribute,
+    product_type_variant_reference_attribute,
+    page,
+    page_type_list,
+    permission_manage_products,
+    warehouse,
+    variant,
+):
+    # given
+    query = CREATE_VARIANT_MUTATION
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    sku = "1"
+
+    product_type.variant_attributes.clear()
+    product_type.variant_attributes.add(
+        product_type_page_reference_attribute,
+        product_type_product_reference_attribute,
+        product_type_variant_reference_attribute,
+    )
+
+    # assigned reference types that do not match product/page types of references
+    # that are provided in the input
+    product_type_page_reference_attribute.reference_page_types.add(page_type_list[1])
+    product_type_product_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+    product_type_variant_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_page_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_variant_reference_attribute.id
+    )
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+
+    stocks = [
+        {
+            "warehouse": graphene.Node.to_global_id("Warehouse", warehouse.pk),
+            "quantity": 20,
+        }
+    ]
+
+    variables = {
+        "input": {
+            "product": product_id,
+            "sku": sku,
+            "stocks": stocks,
+            "attributes": [
+                {"id": page_ref_attr_id, "references": [page_ref]},
+                {"id": product_ref_attr_id, "references": [product_ref]},
+                {"id": variant_ref_attr_id, "references": [variant_ref]},
+            ],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    data = get_graphql_content(response)["data"]["productVariantCreate"]
+
+    errors = data["errors"]
+    assert not data["productVariant"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == ProductErrorCode.INVALID.name
+    assert errors[0]["field"] == "attributes"
+    assert set(errors[0]["attributes"]) == {
+        page_ref_attr_id,
+        product_ref_attr_id,
+        variant_ref_attr_id,
+    }
 
 
 @patch("saleor.plugins.manager.PluginsManager.product_variant_created")

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -677,6 +677,7 @@ QUERY_UPDATE_VARIANT_ATTRIBUTES = """
                     field
                     code
                     message
+                    attributes
                 }
             }
         }
@@ -1687,11 +1688,11 @@ def test_update_product_variant_with_duplicated_attribute(
     content = get_graphql_content(response)
 
     data = content["data"]["productVariantUpdate"]
-    assert data["errors"][0] == {
-        "field": "attributes",
-        "code": ProductErrorCode.DUPLICATED_INPUT_ITEM.name,
-        "message": ANY,
-    }
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "attributes"
+    assert errors[0]["code"] == ProductErrorCode.DUPLICATED_INPUT_ITEM.name
+    assert set(errors[0]["attributes"]) == {color_attribute_id, size_attribute_id}
 
 
 def test_update_product_variant_with_current_file_attribute(
@@ -1788,11 +1789,11 @@ def test_update_product_variant_with_duplicated_file_attribute(
     content = get_graphql_content(response)
 
     data = content["data"]["productVariantUpdate"]
-    assert data["errors"][0] == {
-        "field": "attributes",
-        "code": ProductErrorCode.DUPLICATED_INPUT_ITEM.name,
-        "message": ANY,
-    }
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "attributes"
+    assert errors[0]["code"] == ProductErrorCode.DUPLICATED_INPUT_ITEM.name
+    assert set(errors[0]["attributes"]) == {file_attribute_id}
 
 
 def test_update_product_variant_with_file_attribute_new_value_is_not_created(
@@ -2062,6 +2063,134 @@ def test_update_product_variant_with_category_reference_attribute(
     assert variant_data["attributes"][0]["values"][0]["reference"] == reference
 
 
+def test_update_product_variant_with_reference_attributes_and_reference_types_defined(
+    staff_api_client,
+    product_list,
+    page,
+    product_type_page_reference_attribute,
+    product_type_product_reference_attribute,
+    product_type_variant_reference_attribute,
+    permission_manage_products,
+):
+    # given
+    variant = product_list[0].variants.first()
+    sku = str(uuid4())[:12]
+    assert not variant.sku == sku
+
+    product_type = variant.product.product_type
+    product_type.variant_attributes.clear()
+    product_type.variant_attributes.add(
+        product_type_page_reference_attribute,
+        product_type_product_reference_attribute,
+        product_type_variant_reference_attribute,
+    )
+
+    reference_product = product_list[1]
+    reference_variant = product_list[2].variants.first()
+    product_type_page_reference_attribute.reference_page_types.add(page.page_type)
+    product_type_product_reference_attribute.reference_product_types.add(
+        reference_product.product_type
+    )
+    product_type_variant_reference_attribute.reference_product_types.add(
+        variant.product.product_type
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_page_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_variant_reference_attribute.id
+    )
+    variant_ref = graphene.Node.to_global_id("ProductVariant", reference_variant.pk)
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", reference_product.pk)
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {
+        "id": variant_id,
+        "sku": sku,
+        "attributes": [
+            {"id": page_ref_attr_id, "references": [page_ref]},
+            {"id": product_ref_attr_id, "references": [product_ref]},
+            {"id": variant_ref_attr_id, "references": [variant_ref]},
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_UPDATE_VARIANT_ATTRIBUTES,
+        variables,
+        permissions=[permission_manage_products],
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    data = content["data"]["productVariantUpdate"]
+    assert not data["errors"]
+    variant_data = data["productVariant"]
+    assert variant_data["sku"] == sku
+    assert len(variant_data["attributes"]) == len(variables["attributes"])
+    expected_attributes_data = [
+        {
+            "attribute": {"slug": product_type_page_reference_attribute.slug},
+            "values": [
+                {
+                    "id": ANY,
+                    "slug": f"{variant.pk}_{page.id}",
+                    "file": None,
+                    "richText": None,
+                    "plainText": None,
+                    "reference": page_ref,
+                    "name": page.title,
+                    "boolean": None,
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+        {
+            "attribute": {"slug": product_type_product_reference_attribute.slug},
+            "values": [
+                {
+                    "id": ANY,
+                    "slug": f"{variant.pk}_{reference_product.id}",
+                    "file": None,
+                    "richText": None,
+                    "plainText": None,
+                    "reference": product_ref,
+                    "name": reference_product.name,
+                    "boolean": None,
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+        {
+            "attribute": {"slug": product_type_variant_reference_attribute.slug},
+            "values": [
+                {
+                    "id": ANY,
+                    "slug": f"{variant.pk}_{reference_variant.id}",
+                    "file": None,
+                    "richText": None,
+                    "plainText": None,
+                    "reference": variant_ref,
+                    "name": f"{reference_variant.product.name}: {reference_variant.name}",
+                    "boolean": None,
+                    "date": None,
+                    "dateTime": None,
+                }
+            ],
+        },
+    ]
+    for attr_data in variant_data["attributes"]:
+        assert attr_data in expected_attributes_data
+
+
 def test_update_product_variant_with_single_reference_attributes(
     staff_api_client,
     product,
@@ -2311,11 +2440,12 @@ def test_update_product_variant_requires_values(
     assert len(content["data"]["productVariantUpdate"]["errors"]) == 1, (
         f"expected: {message}"
     )
-    assert content["data"]["productVariantUpdate"]["errors"][0] == {
-        "field": "attributes",
-        "message": message,
-        "code": code,
-    }
+    errors = content["data"]["productVariantUpdate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "attributes"
+    assert errors[0]["code"] == code
+    assert errors[0]["message"] == message
+    assert set(errors[0]["attributes"]) == {attr_id}
     assert not variant.product.variants.filter(sku=sku).exists()
 
 
@@ -2348,13 +2478,96 @@ def test_update_product_variant_requires_attr_value_when_is_required(
     )
     variant.refresh_from_db()
     content = get_graphql_content(response)
-    assert len(content["data"]["productVariantUpdate"]["errors"]) == 1
-    assert content["data"]["productVariantUpdate"]["errors"][0] == {
-        "field": "attributes",
-        "message": "Attribute expects a value but none were given.",
-        "code": "REQUIRED",
-    }
+    errors = content["data"]["productVariantUpdate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "attributes"
+    assert errors[0]["code"] == ProductErrorCode.REQUIRED.name
+    assert errors[0]["message"] == "Attribute expects a value but none were given."
+    assert set(errors[0]["attributes"]) == {attr_id}
     assert not variant.product.variants.filter(sku=sku).exists()
+
+
+def test_update_product_variant_with_reference_attributes_ref_not_in_available_choices(
+    staff_api_client,
+    product_list,
+    page,
+    product_type_page_reference_attribute,
+    product_type_product_reference_attribute,
+    product_type_variant_reference_attribute,
+    permission_manage_products,
+    page_type_list,
+    product_type_with_variant_attributes,
+):
+    # given
+    variant = product_list[0].variants.first()
+    sku = str(uuid4())[:12]
+    assert not variant.sku == sku
+
+    product_type = variant.product.product_type
+    product_type.variant_attributes.clear()
+    product_type.variant_attributes.add(
+        product_type_page_reference_attribute,
+        product_type_product_reference_attribute,
+        product_type_variant_reference_attribute,
+    )
+
+    reference_product = product_list[1]
+    reference_variant = product_list[2].variants.first()
+    # assigned reference types that do not match product/page types of references
+    # that are provided in the input
+    product_type_page_reference_attribute.reference_page_types.add(page_type_list[1])
+    product_type_product_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+    product_type_variant_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_page_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_variant_reference_attribute.id
+    )
+    variant_ref = graphene.Node.to_global_id("ProductVariant", reference_variant.pk)
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", reference_product.pk)
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {
+        "id": variant_id,
+        "sku": sku,
+        "attributes": [
+            {"id": page_ref_attr_id, "references": [page_ref]},
+            {"id": product_ref_attr_id, "references": [product_ref]},
+            {"id": variant_ref_attr_id, "references": [variant_ref]},
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_UPDATE_VARIANT_ATTRIBUTES,
+        variables,
+        permissions=[permission_manage_products],
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    data = content["data"]["productVariantUpdate"]
+    errors = data["errors"]
+    assert not data["productVariant"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == ProductErrorCode.INVALID.name
+    assert errors[0]["field"] == "attributes"
+    assert set(errors[0]["attributes"]) == {
+        page_ref_attr_id,
+        product_ref_attr_id,
+        variant_ref_attr_id,
+    }
 
 
 def test_update_product_variant_with_price_does_not_raise_price_validation_error(

--- a/saleor/page/tests/fixtures/page_type.py
+++ b/saleor/page/tests/fixtures/page_type.py
@@ -14,7 +14,9 @@ def page_type(db, size_page_attribute, tag_page_attribute):
 
 @pytest.fixture
 def page_type_with_rich_text_attribute(db, rich_text_attribute_page_type):
-    page_type = PageType.objects.create(name="Test page type", slug="test-page-type")
+    page_type = PageType.objects.create(
+        name="Test page type", slug="test-page-type-rich"
+    )
     page_type.page_attributes.add(rich_text_attribute_page_type)
     return page_type
 


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/18071

Ensure that only references with product/page type that match the one from choices can be defined as attribute value. In case the reference types is not specified in attribute, all objects of the specific type can be set as a reference.

Add validation for page and variant creation and update.
Tests for bulk mutations will be added separately

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New mi...